### PR TITLE
fix: do not alter the parent HTML

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -20,8 +20,6 @@ Cypress.on("run:start", () => {
 
   Cypress.on("test:before:run", () => {
     componentInstance?.remove();
-    const containerEl = getContainerEl();
-    containerEl.innerHTML = "";
   });
 });
 


### PR DESCRIPTION
Observe the following error:

```
  1) header
       with no logo it collapses:
     Error: This `ChildPart` has no `parentNode` and therefore cannot accept a value. This likely means the element containing the part was manipulated in an unsupported way outside of Lit's control such that the part's marker nodes were ejected from DOM. For example, setting the element's `innerHTML` or `textContent` can do this.
      at ChildPart._$setValue (webpack://Banked/./node_modules/lit-html/development/lit-html.js?:892:19)
      at render (webpack://Banked/./node_modules/lit-html/development/lit-html.js?:333:10)
      at Context.mount (webpack://Banked/./cypress/support/lit/index.ts?:17:46)
      at wrapped (http://localhost:8080/__cypress/runner/cypress_runner.js:157179:43)
      at <unknown> (http://localhost:8080/__cypress/runner/cypress_runner.js:155929:15)
      at tryCatcher (http://localhost:8080/__cypress/runner/cypress_runner.js:11318:23)
      at Promise._settlePromiseFromHandler (http://localhost:8080/__cypress/runner/cypress_runner.js:9253:31)
      at Promise._settlePromise (http://localhost:8080/__cypress/runner/cypress_runner.js:9310:18)
      at Promise._settlePromiseCtx (http://localhost:8080/__cypress/runner/cypress_runner.js:9347:10)
```

Attempting fix on an alpha releases