### PR TITLE
Use 'in' operator instead of 'hasOwnProperty'

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -59,7 +59,7 @@ export const mount = <T extends keyof HTMLElementTagNameMap>(
           Array.isArray(properties) === false
         ) {
           for (const prop in properties) {
-            if (Object.prototype.hasOwnProperty.call(el, prop)) {
+            if (prop in el) {
               const val = properties[prop]!;
               el[prop] = val;
             }


### PR DESCRIPTION
This PR replaces the `hasOwnProperty` operator with `in` when checking the properties in the mount function.

## Reason
When currently passing properties during the mount function, it works great with "simple" properties but it fails with properties that have `get` and `set`.

Consider the following custom element:
```
class MyComponent extends HTMLElement {
    constructor() {
        super();
        this._message = '';
    }
    get message() {
        return this._message
    }
    set message(val) {
        this._message = val
        this.innerHTML = this._message;
    }
}
customElements.define('my-component', MyComponent)
```
and the following (currently failing) test:
```
  it("renders the message", () => {
    cy.mount(`<my-component></my-component>`, {
      properties: {
        message: "foo bar"
      }
    })
    cy.get("my-component").shadow().should("contains.text", "foo bar");
  });
```

## Proposed solution
The issue seems to be that `hasOwnProperty` does not recognise the property getter.
By replacing it with the `in` operator, the prop is recognised and it works. The only potential downside is that the `in` operator also recognises inherited properties but this is not necessarily an issue.